### PR TITLE
Update script for Meteor 0.6.5.

### DIFF
--- a/meteor.sh
+++ b/meteor.sh
@@ -3,6 +3,9 @@
 # IP or URL of the server you want to deploy to
 export APP_HOST=example.com
 
+# Change the port if you want to run on an alternate port
+export PORT=80
+
 # Uncomment this if your host is an EC2 instance
 # export EC2_PEM_FILE=path/to/your/file.pem
 
@@ -42,7 +45,7 @@ echo Deploying...
 $METEOR_CMD bundle bundle.tgz > /dev/null 2>&1 &&
 scp $SSH_OPT bundle.tgz $SSH_HOST:/tmp/ > /dev/null 2>&1 &&
 rm bundle.tgz > /dev/null 2>&1 &&
-ssh $SSH_OPT $SSH_HOST MONGO_URL=$MONGO_URL ROOT_URL=$ROOT_URL APP_DIR=$APP_DIR 'sudo -E bash -s' > /dev/null 2>&1 <<'ENDSSH'
+ssh $SSH_OPT $SSH_HOST PORT=$PORT MONGO_URL=$MONGO_URL ROOT_URL=$ROOT_URL APP_DIR=$APP_DIR 'sudo -E bash -s' > /dev/null 2>&1 <<'ENDSSH'
 if [ ! -d "$APP_DIR" ]; then
 mkdir -p $APP_DIR
 chown -R www-data:www-data $APP_DIR
@@ -52,21 +55,21 @@ forever stop bundle/main.js
 rm -rf bundle
 tar xfz /tmp/bundle.tgz -C $APP_DIR
 rm /tmp/bundle.tgz
-pushd bundle/server/node_modules
+pushd bundle/programs/server/node_modules
 rm -rf fibers
-npm install fibers
+npm install fibers@1.0.1
 popd
 chown -R www-data:www-data bundle
-patch -u bundle/server/server.js <<'ENDPATCH'
-@@ -286,6 +286,8 @@
-     app.listen(port, function() {
-       if (argv.keepalive)
-         console.log("LISTENING"); // must match run.js
+patch -u bundle/programs/server/packages/webapp.js <<'ENDPATCH'
+@@ -464,6 +464,8 @@
+     httpServer.listen(localPort, localIp, Meteor.bindEnvironment(function() {          // 445
+       if (argv.keepalive || true)                                                      // 446
+         console.log("LISTENING"); // must match run.js                                 // 447
 +      process.setgid('www-data');
 +      process.setuid('www-data');
-     });
- 
-   }).run();
+       var port = httpServer.address().port;                                            // 448
+       if (bind.viaProxy && bind.viaProxy.proxyEndpoint) {                              // 449
+         WebAppInternals.bindToProxy(bind.viaProxy);                                    // 450
 ENDPATCH
 forever start bundle/main.js
 popd


### PR DESCRIPTION
Need to provide `PORT` to Meteor.

`docs.meteor.com` recommends `npm install fibers@1.0.1`, so I changed that.

Some paths, and the code snippet that we patch have also changed.

May want to consider Demeteorizer, but that's another issue.
